### PR TITLE
Fix Hero section overlapping with NavBar on mobile

### DIFF
--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -12,7 +12,7 @@ export default function Hero() {
   return (
     <section
       aria-label="Hero"
-      className="relative min-h-[82vh] flex items-center justify-center overflow-hidden"
+      className="relative min-h-[82vh] flex items-center justify-center overflow-hidden pt-36 md:pt-32"
     >
       {/* Background Elements */}
       <div className="absolute inset-0 bg-gradient-to-b from-white via-gray-50 to-gray-100 dark:from-gray-900 dark:via-gray-900 dark:to-gray-800 -z-10" />


### PR DESCRIPTION
Resolved an issue where the Hero section content overlapped with the sticky NavBar on mobile devices.  
- Added top padding/margin on mobile to ensure visibility  
- Ensured spacing consistency with desktop layout  
- Kept scroll animations and responsiveness intact  
