### PR TITLE
Fix 403 error on host access

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -1,0 +1,50 @@
+# Enable rewrite engine
+RewriteEngine On
+
+# Security: Prevent directory listing
+Options -Indexes
+
+# Allow direct access to existing files (CSS, JS, images, etc.)
+RewriteCond %{REQUEST_FILENAME} -f
+RewriteRule ^ - [L]
+
+# Allow direct access to existing directories
+RewriteCond %{REQUEST_FILENAME} -d
+RewriteRule ^ - [L]
+
+# Handle clean URLs by redirecting to .html files
+# For example: /about -> /about.html
+RewriteCond %{REQUEST_FILENAME}.html -f
+RewriteRule ^(.*)$ $1.html [L]
+
+# Fallback to index.html for client-side routing (SPA behavior)
+RewriteCond %{REQUEST_FILENAME} !-f
+RewriteCond %{REQUEST_FILENAME} !-d
+RewriteRule ^ /index.html [L]
+
+# Set proper MIME types for modern web files
+<IfModule mod_mime.c>
+  AddType application/javascript js
+  AddType text/css css
+  AddType image/svg+xml svg
+  AddType image/webp webp
+</IfModule>
+
+# Enable compression for better performance
+<IfModule mod_deflate.c>
+  AddOutputFilterByType DEFLATE text/html text/plain text/xml text/css text/javascript application/javascript application/json
+</IfModule>
+
+# Set caching headers for static assets
+<IfModule mod_expires.c>
+  ExpiresActive On
+  ExpiresByType image/jpg "access plus 1 year"
+  ExpiresByType image/jpeg "access plus 1 year"
+  ExpiresByType image/png "access plus 1 year"
+  ExpiresByType image/gif "access plus 1 year"
+  ExpiresByType image/svg+xml "access plus 1 year"
+  ExpiresByType image/webp "access plus 1 year"
+  ExpiresByType text/css "access plus 1 month"
+  ExpiresByType application/javascript "access plus 1 month"
+  ExpiresByType text/javascript "access plus 1 month"
+</IfModule>


### PR DESCRIPTION
- Add .htaccess with URL rewrite rules for Next.js static exports
- Enable clean URLs (e.g., /about instead of /about.html)
- Configure proper MIME types and caching headers
- Add compression support for better performance
- Fallback to index.html for client-side routing

This fixes 403 errors caused by missing URL rewriting configuration on Apache-based hosting (Hostinger).